### PR TITLE
Fix dependency versions to released artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,17 +13,17 @@
   </modules>
   <properties>
     <java.version>21</java.version>
-    <jackson.version>2.20.0</jackson.version>
+    <jackson.version>2.17.1</jackson.version>
     <azure.datalake.version>12.24.2</azure.datalake.version>
     <azure.identity.version>1.17.0</azure.identity.version>
-    <junit.jupiter.version>5.13.4</junit.jupiter.version>
+    <junit.jupiter.version>5.10.2</junit.jupiter.version>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.5.5</version>
+        <version>3.2.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Summary
- align parent POM with released versions of Spring Boot, Jackson, and JUnit

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.2.4 from/to central; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b907b892ec8328a1630d93cd29f078